### PR TITLE
Fix GitHub Copilot capitalization

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -9,9 +9,9 @@
    <extension
          point="org.eclipse.ui.actionSets">
       <actionSet
-            description="This will open up the menu for the Github Copilot extension."
+          description="This will open up the menu for the GitHub Copilot extension."
             id="me.masecla.copilot.CopilotActionSet"
-            label="Github Copilot"
+          label="GitHub Copilot"
             visible="true">
             <menu
             	id="me.masecla.copilot.CopilotMenu"


### PR DESCRIPTION
## Summary
- update plugin.xml text to use "GitHub Copilot"

## Testing
- `grep -n "GitHub Copilot" -n plugin.xml`

------
https://chatgpt.com/codex/tasks/task_e_684852a2c658832da5484498b0749ac5